### PR TITLE
Remove unneeded require('path')

### DIFF
--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -1,8 +1,6 @@
 /*jslint node: true */
 'use strict';
 
-var path = require('path');
-
 var esc = function(s){
   if (typeof s !== 'string'){
     return '';


### PR DESCRIPTION
Variable is defined but never used

Breaks usage on non-node platform (e.g. browser)